### PR TITLE
Add development environment setup for Cursor Cloud

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Personal website (amritav.com) built with **Next.js 15** (static export). Three independent npm packages:
+
+| Package | Path | Purpose |
+|---|---|---|
+| Root (frontend) | `/workspace` | Next.js app — `npm run dev` on port 3000 |
+| Contributions function | `/workspace/functions/contributions` | Firebase Cloud Function (Node 18) |
+| Strava function | `/workspace/strava` | Firebase Cloud Function in TypeScript (Node 22) — run `npm run build` to compile |
+
+### Running the frontend
+
+```
+npm run dev        # starts Next.js dev server on port 3000
+npm run build      # static export to out/
+```
+
+### Lint / Format
+
+- **Root**: `npx prettier --check .` (formatter only; no ESLint configured at root)
+- **functions/contributions**: `npx eslint .`
+- **strava**: `npx eslint .` (also `npm run build` to type-check via `tsc`)
+
+### Known caveats
+
+- **Case-sensitivity symlink**: `styles/home.module.css` is a symlink to `Home.module.css`. The code imports the lowercase name, which works on macOS (case-insensitive FS) but fails on Linux without this symlink. The update script recreates it automatically.
+- **API routes warning**: `next build` emits a warning about API routes and `output: 'export'` — this is expected and harmless since the site is statically exported.
+- **Cloud Functions are optional for frontend dev**: The frontend calls deployed Firebase Cloud Function URLs, not localhost. To develop Cloud Functions locally, you need `firebase-tools` CLI and the relevant API keys (`STRAVA_CLIENT_ID`, `STRAVA_CLIENT_SECRET`, `OPENAI_API_KEY`, `GITHUB_PERSONAL_ACCESS_TOKEN`).
+- **Pre-existing lint issues**: Both `functions/contributions` and `strava` have pre-existing ESLint warnings/errors; `prettier --check` also reports formatting issues across the codebase.

--- a/styles/home.module.css
+++ b/styles/home.module.css
@@ -1,0 +1,1 @@
+Home.module.css


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Next.js personal website so it can be developed on Linux-based cloud VMs.

### Changes

- **`AGENTS.md`**: Added Cursor Cloud specific instructions documenting how to run, lint, build, and test the project, plus known caveats (case-sensitivity, API routes warning, pre-existing lint issues).
- **`styles/home.module.css`** (symlink): Created a lowercase symlink pointing to `Home.module.css` to fix a case-sensitivity issue where the import in `pages/index.js` uses lowercase `home.module.css` but the file is `Home.module.css`. This works on macOS (case-insensitive FS) but fails on Linux without the symlink.

### Update Script

The VM startup script installs npm dependencies for all three packages (root, `functions/contributions`, `strava`) and ensures the case-sensitivity symlink exists.

### Verification

- `npm run dev` — Next.js dev server starts and serves all pages (homepage, blog posts, connections puzzle, activities, recommend)
- `npm run build` — Static export completes successfully
- `npx prettier --check .` — Runs (pre-existing formatting issues in codebase)
- ESLint in `functions/contributions` and `strava` — Runs (pre-existing lint issues)
- `npm run build` in `strava/` — TypeScript compilation succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2f83ddf-6dc8-406a-9406-ae63015439e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2f83ddf-6dc8-406a-9406-ae63015439e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

