### PR TITLE
Add travel schedule page (/travel)

### DIFF
--- a/lib/travelSchedule.js
+++ b/lib/travelSchedule.js
@@ -1,0 +1,56 @@
+import { addDays, eachDayOfInterval, format, isWithinInterval, parseISO } from "date-fns";
+
+// Edit this list to match your real travel plans.
+// Dates should be YYYY-MM-DD (local time). Ranges are inclusive.
+export const travelSchedule = [
+  {
+    startDate: "2026-04-01",
+    endDate: "2026-04-04",
+    location: "San Francisco, CA",
+    details: "Home base",
+  },
+  {
+    startDate: "2026-04-05",
+    endDate: "2026-04-07",
+    location: "Los Angeles, CA",
+    details: "Work meetings",
+  },
+  {
+    startDate: "2026-04-08",
+    endDate: "2026-04-14",
+    location: "San Francisco, CA",
+    details: "Home base",
+  },
+];
+
+function normalizeRange(item) {
+  const start = parseISO(item.startDate);
+  const end = parseISO(item.endDate);
+  return { start, end };
+}
+
+export function buildTwoWeekTravelCalendar({
+  startDate = new Date(),
+  days = 14,
+  schedule = travelSchedule,
+} = {}) {
+  const start = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+  const end = addDays(start, days - 1);
+  const items = schedule.map((item) => ({ ...item, ...normalizeRange(item) }));
+
+  return eachDayOfInterval({ start, end }).map((day) => {
+    const matches = items
+      .filter((it) => isWithinInterval(day, { start: it.start, end: it.end }))
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+    const primary = matches[0] ?? null;
+
+    return {
+      date: format(day, "yyyy-MM-dd"),
+      label: format(day, "EEE, MMM d"),
+      location: primary?.location ?? "—",
+      details: primary?.details ?? "",
+    };
+  });
+}
+

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import Layout, { siteTitle } from "../components/layout";
 import utilStyles from "../styles/utils.module.css";
-import styles from "../styles/home.module.css";
+import styles from "../styles/Home.module.css";
 import { getSortedPostsData } from "../lib/posts";
 import Date from "../components/date";
 import "../components/firebase";
@@ -49,6 +49,11 @@ export default function Home({ allPostsData }) {
           <Link href={`/posts/activities`} className={utilStyles.link}>
             activity calendar
           </Link>{" "}
+          or my{" "}
+          <Link href={`/travel`} className={utilStyles.link}>
+            travel schedule
+          </Link>
+          .
           I made for myself! You can find me on{" "}
           <a href="https://twitter.com/iamrita98" className={utilStyles.link}>
             Twitter

--- a/pages/travel.js
+++ b/pages/travel.js
@@ -1,0 +1,51 @@
+import Head from "next/head";
+import Layout from "../components/layout";
+import headerFont from "../components/Font";
+import utilStyles from "../styles/utils.module.css";
+import styles from "../styles/travel.module.css";
+import { buildTwoWeekTravelCalendar } from "../lib/travelSchedule";
+
+export async function getStaticProps() {
+  const days = buildTwoWeekTravelCalendar();
+  return { props: { days } };
+}
+
+export default function Travel({ days }) {
+  return (
+    <Layout>
+      <Head>
+        <title>Travel</title>
+      </Head>
+      <article>
+        <h1 className={headerFont.className}>Travel (Next 2 Weeks)</h1>
+        <p className={styles.paragraph}>
+          This page shows where I expect to be over the next 14 days. Plans can
+          change—this is the best current version.
+        </p>
+
+        <div className={styles.schedule}>
+          {days.map((d) => (
+            <div key={d.date} className={styles.dayRow}>
+              <div className={styles.date}>{d.label}</div>
+              <div>
+                <div className={styles.location}>{d.location}</div>
+                {d.details ? (
+                  <div className={styles.details}>{d.details}</div>
+                ) : (
+                  <div className={`${styles.details} ${styles.muted}`}>
+                    No additional details.
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <p className={`${styles.paragraph} ${utilStyles.fontWeightNormal}`}>
+          Want to edit this? Update <code>lib/travelSchedule.js</code>.
+        </p>
+      </article>
+    </Layout>
+  );
+}
+

--- a/styles/travel.module.css
+++ b/styles/travel.module.css
@@ -1,0 +1,38 @@
+.paragraph,
+.schedule {
+  border: 1px solid black;
+  font-size: 18px;
+  border-radius: 8px;
+  background-color: #f1f5fd;
+  padding: 32px;
+}
+
+.schedule {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dayRow {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.date {
+  font-weight: 700;
+}
+
+.location {
+  font-weight: 700;
+}
+
+.details {
+  margin-top: 4px;
+  opacity: 0.9;
+}
+
+.muted {
+  opacity: 0.75;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a new `pages/travel.js` route that shows a 14-day travel calendar generated from `lib/travelSchedule.js` (easy to edit via date ranges).

Also links to the travel page from the homepage and adds basic styling via `styles/travel.module.css`.

Notes:
- Site uses static export; page is generated via `getStaticProps`.
- Fixed a case-sensitive CSS import on the homepage (`Home.module.css`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93d898c1-ba2f-4a7c-b481-4ea737fb9276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93d898c1-ba2f-4a7c-b481-4ea737fb9276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

