### PR TITLE
Add Weekend Plans page with Google Calendar integration

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,7 @@ import Head from "next/head";
 import Link from "next/link";
 import Layout, { siteTitle } from "../components/layout";
 import utilStyles from "../styles/utils.module.css";
-import styles from "../styles/home.module.css";
+import styles from "../styles/Home.module.css";
 import { getSortedPostsData } from "../lib/posts";
 import Date from "../components/date";
 import "../components/firebase";
@@ -49,7 +49,11 @@ export default function Home({ allPostsData }) {
           <Link href={`/posts/activities`} className={utilStyles.link}>
             activity calendar
           </Link>{" "}
-          I made for myself! You can find me on{" "}
+          or see what I have planned for the{" "}
+          <Link href={`/posts/weekend`} className={utilStyles.link}>
+            weekend
+          </Link>
+          ! You can find me on{" "}
           <a href="https://twitter.com/iamrita98" className={utilStyles.link}>
             Twitter
           </a>{" "}

--- a/pages/posts/weekend.js
+++ b/pages/posts/weekend.js
@@ -1,0 +1,294 @@
+import Layout from "../../components/layout";
+import Head from "next/head";
+import headerFont from "../../components/Font";
+import styles from "../../styles/weekend.module.css";
+import { useState, useEffect, useCallback, useRef } from "react";
+
+const SCOPES = "https://www.googleapis.com/auth/calendar.readonly";
+const CLIENT_ID =
+  "773951288107-iq7t5e39m3v5t0s3q97bjnq2j9f5k56r.apps.googleusercontent.com";
+const DISCOVERY_DOC =
+  "https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest";
+
+function getUpcomingWeekend() {
+  const now = new Date();
+  const day = now.getDay();
+
+  let satOffset, sunOffset;
+  if (day === 6) {
+    satOffset = 0;
+    sunOffset = 1;
+  } else if (day === 0) {
+    satOffset = -1;
+    sunOffset = 0;
+  } else {
+    satOffset = 6 - day;
+    sunOffset = 7 - day;
+  }
+
+  const saturday = new Date(now);
+  saturday.setDate(now.getDate() + satOffset);
+  saturday.setHours(0, 0, 0, 0);
+
+  const sunday = new Date(now);
+  sunday.setDate(now.getDate() + sunOffset);
+  sunday.setHours(23, 59, 59, 999);
+
+  return { saturday, sunday };
+}
+
+function formatTime(dateString) {
+  const d = new Date(dateString);
+  return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+function formatDateHeading(date) {
+  return date.toLocaleDateString([], {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function groupEventsByDay(events, saturday) {
+  const satDate = saturday.toDateString();
+  const satEvents = [];
+  const sunEvents = [];
+
+  for (const event of events) {
+    const start = event.start.dateTime || event.start.date;
+    const eventDate = new Date(start).toDateString();
+    if (eventDate === satDate) {
+      satEvents.push(event);
+    } else {
+      sunEvents.push(event);
+    }
+  }
+
+  return { satEvents, sunEvents };
+}
+
+function EventCard({ event }) {
+  const isAllDay = !event.start.dateTime;
+  const startTime = event.start.dateTime
+    ? formatTime(event.start.dateTime)
+    : null;
+  const endTime = event.end.dateTime ? formatTime(event.end.dateTime) : null;
+
+  return (
+    <div className={styles.eventCard}>
+      <div className={styles.eventTime}>
+        {isAllDay ? (
+          <span className={styles.allDayBadge}>All day</span>
+        ) : (
+          <>
+            {startTime}
+            {endTime ? ` - ${endTime}` : ""}
+          </>
+        )}
+      </div>
+      <div className={styles.eventDetails}>
+        <p className={styles.eventTitle}>{event.summary || "(No title)"}</p>
+        {event.location && (
+          <p className={styles.eventLocation}>{event.location}</p>
+        )}
+        {event.description && (
+          <p className={styles.eventDescription}>
+            {event.description.length > 120
+              ? event.description.slice(0, 120) + "..."
+              : event.description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function Weekend() {
+  const [events, setEvents] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [isSignedIn, setIsSignedIn] = useState(false);
+  const [gapiReady, setGapiReady] = useState(false);
+  const [gisReady, setGisReady] = useState(false);
+  const tokenClientRef = useRef(null);
+
+  const fetchEvents = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { saturday, sunday } = getUpcomingWeekend();
+      const response = await window.gapi.client.calendar.events.list({
+        calendarId: "primary",
+        timeMin: saturday.toISOString(),
+        timeMax: sunday.toISOString(),
+        singleEvents: true,
+        orderBy: "startTime",
+        maxResults: 50,
+      });
+      setEvents(response.result.items || []);
+    } catch (err) {
+      setError(
+        err?.result?.error?.message || "Failed to fetch calendar events."
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const loadGapi = () => {
+      const script = document.createElement("script");
+      script.src = "https://apis.google.com/js/api.js";
+      script.async = true;
+      script.defer = true;
+      script.onload = () => {
+        window.gapi.load("client", async () => {
+          await window.gapi.client.init({
+            discoveryDocs: [DISCOVERY_DOC],
+          });
+          setGapiReady(true);
+        });
+      };
+      document.head.appendChild(script);
+    };
+
+    const loadGis = () => {
+      const script = document.createElement("script");
+      script.src = "https://accounts.google.com/gsi/client";
+      script.async = true;
+      script.defer = true;
+      script.onload = () => {
+        setGisReady(true);
+      };
+      document.head.appendChild(script);
+    };
+
+    loadGapi();
+    loadGis();
+  }, []);
+
+  useEffect(() => {
+    if (!gapiReady || !gisReady) return;
+
+    tokenClientRef.current = window.google.accounts.oauth2.initTokenClient({
+      client_id: CLIENT_ID,
+      scope: SCOPES,
+      callback: (tokenResponse) => {
+        if (tokenResponse.error) {
+          setError("Authorization failed. Please try again.");
+          return;
+        }
+        setIsSignedIn(true);
+        fetchEvents();
+      },
+    });
+  }, [gapiReady, gisReady, fetchEvents]);
+
+  const handleSignIn = () => {
+    if (tokenClientRef.current) {
+      tokenClientRef.current.requestAccessToken({ prompt: "consent" });
+    }
+  };
+
+  const handleSignOut = () => {
+    const token = window.gapi.client.getToken();
+    if (token) {
+      window.google.accounts.oauth2.revoke(token.access_token);
+      window.gapi.client.setToken(null);
+    }
+    setIsSignedIn(false);
+    setEvents(null);
+  };
+
+  const { saturday, sunday } = getUpcomingWeekend();
+  const grouped = events ? groupEventsByDay(events, saturday) : null;
+
+  return (
+    <Layout>
+      <Head>
+        <title>Weekend Plans</title>
+      </Head>
+
+      <article className={styles.container}>
+        <div className={styles.headerRow}>
+          <h1 className={headerFont.className}>Weekend Plans</h1>
+          {isSignedIn && (
+            <button onClick={handleSignOut} className={styles.signOutButton}>
+              Sign out
+            </button>
+          )}
+        </div>
+
+        {!isSignedIn ? (
+          <div className={styles.signInContainer}>
+            <p>
+              Connect your Google Calendar to see what you have planned for the
+              upcoming weekend.
+            </p>
+            <button
+              onClick={handleSignIn}
+              className={styles.signInButton}
+              disabled={!gapiReady || !gisReady}
+            >
+              {gapiReady && gisReady
+                ? "Sign in with Google"
+                : "Loading..."}
+            </button>
+          </div>
+        ) : loading ? (
+          <div className={styles.loading}>
+            <span className={styles.spinner} />
+            Fetching your weekend events...
+          </div>
+        ) : error ? (
+          <div className={styles.errorBox}>{error}</div>
+        ) : grouped ? (
+          <>
+            <p className={styles.weekendLabel}>
+              {formatDateHeading(saturday)} &ndash;{" "}
+              {formatDateHeading(sunday)}
+            </p>
+
+            <div className={styles.daySection}>
+              <h2 className={`${styles.dayHeading} ${headerFont.className}`}>
+                Saturday
+              </h2>
+              {grouped.satEvents.length > 0 ? (
+                grouped.satEvents.map((event) => (
+                  <EventCard key={event.id} event={event} />
+                ))
+              ) : (
+                <div className={styles.emptyDay}>
+                  Nothing planned &mdash; enjoy the free time!
+                </div>
+              )}
+            </div>
+
+            <div className={styles.daySection}>
+              <h2 className={`${styles.dayHeading} ${headerFont.className}`}>
+                Sunday
+              </h2>
+              {grouped.sunEvents.length > 0 ? (
+                grouped.sunEvents.map((event) => (
+                  <EventCard key={event.id} event={event} />
+                ))
+              ) : (
+                <div className={styles.emptyDay}>
+                  Nothing planned &mdash; enjoy the free time!
+                </div>
+              )}
+            </div>
+          </>
+        ) : null}
+
+        <div className={styles.infoBox}>
+          This page connects to the Google Calendar API to show your upcoming
+          weekend events. Your calendar data is fetched directly in the browser
+          and is never stored on any server. Sign in with your Google account to
+          get started!
+        </div>
+      </article>
+    </Layout>
+  );
+}

--- a/styles/weekend.module.css
+++ b/styles/weekend.module.css
@@ -1,0 +1,225 @@
+.container {
+  max-width: 100%;
+}
+
+.signInContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  text-align: center;
+}
+
+.signInContainer p {
+  font-size: 1rem;
+  color: #555;
+  margin-bottom: 24px;
+  max-width: 400px;
+}
+
+.signInButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 28px;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #fff;
+  background-color: #1e65e5;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.1s;
+}
+
+.signInButton:hover {
+  background-color: #1550b8;
+}
+
+.signInButton:active {
+  transform: scale(0.98);
+}
+
+.signOutButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  font-size: 0.85rem;
+  color: #666;
+  background: #f0f0f0;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.signOutButton:hover {
+  background-color: #e0e0e0;
+}
+
+.headerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.weekendLabel {
+  font-size: 0.9rem;
+  color: #888;
+  margin-bottom: 24px;
+}
+
+.daySection {
+  margin-bottom: 32px;
+}
+
+.dayHeading {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e8e0f4;
+}
+
+.eventCard {
+  display: flex;
+  gap: 16px;
+  padding: 16px 20px;
+  margin-bottom: 10px;
+  border: 1px solid #e0dce8;
+  border-radius: 10px;
+  background-color: #f8f5fd;
+  transition: box-shadow 0.2s;
+}
+
+.eventCard:hover {
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.eventTime {
+  flex-shrink: 0;
+  min-width: 90px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e65e5;
+  padding-top: 2px;
+}
+
+.eventDetails {
+  flex: 1;
+}
+
+.eventTitle {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0 0 4px;
+  color: #222;
+}
+
+.eventLocation {
+  font-size: 0.85rem;
+  color: #777;
+  margin: 0;
+}
+
+.eventDescription {
+  font-size: 0.85rem;
+  color: #555;
+  margin: 4px 0 0;
+  line-height: 1.4;
+}
+
+.allDayBadge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #9b59b6;
+  background: #f0e6f6;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.emptyDay {
+  padding: 24px 20px;
+  text-align: center;
+  color: #999;
+  font-style: italic;
+  border: 1px dashed #ddd;
+  border-radius: 10px;
+  background-color: #fafafa;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  color: #888;
+  font-size: 1rem;
+}
+
+.spinner {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border: 3px solid #e0e0e0;
+  border-top-color: #1e65e5;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-right: 10px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.errorBox {
+  padding: 16px 20px;
+  border: 1px solid #f5c6cb;
+  border-radius: 8px;
+  background-color: #fff5f5;
+  color: #721c24;
+  font-size: 0.95rem;
+}
+
+.infoBox {
+  padding: 20px;
+  border: 1px solid #e0dce8;
+  border-radius: 10px;
+  background-color: #f8f5fd;
+  font-size: 0.9rem;
+  color: #555;
+  line-height: 1.6;
+  margin-top: 24px;
+}
+
+.infoBox code {
+  background: #eee;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 600px) {
+  .eventCard {
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .eventTime {
+    min-width: unset;
+  }
+
+  .headerRow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new **Weekend Plans** page (`/posts/weekend`) that integrates with Google Calendar to show what you have planned for the upcoming weekend.

## What it does

- **Google Calendar OAuth2 sign-in** via Google Identity Services (GIS) — runs entirely client-side in the browser
- After sign-in, fetches events from your primary Google Calendar for the upcoming **Saturday and Sunday**
- Groups events by day with clear headings, times, titles, locations, and descriptions
- Shows a friendly empty state when a day has no events
- Privacy-first: calendar data is fetched directly in the browser and **never stored on any server**

## Changes

| File | Description |
|------|-------------|
| `pages/posts/weekend.js` | New page component with Google Calendar API integration |
| `styles/weekend.module.css` | Styles for the weekend page (sign-in, event cards, loading/error states) |
| `pages/index.js` | Added link to the weekend page from the homepage intro paragraph; fixed pre-existing case-sensitivity issue in `Home.module.css` import |

## Setup required

For the Google Calendar integration to work in production, a Google Cloud OAuth2 client ID needs to be configured with:
- The production domain added as an authorized JavaScript origin
- The `calendar.readonly` scope enabled
- The OAuth consent screen configured

The current client ID in the code uses the same GCP project as the existing Firebase setup.

## Build verification

- `npm run build` completes successfully with the new page included in the static export
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfad073e-cf17-480b-9437-f69d8c9a73e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfad073e-cf17-480b-9437-f69d8c9a73e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

