### PR TITLE
Add favorite music page

### DIFF
--- a/components/MusicPlayer.js
+++ b/components/MusicPlayer.js
@@ -1,63 +1,23 @@
 import React from "react";
 import styles from "../styles/musicplayer.module.css";
+import { favoriteAlbums, spotifyEmbedUrl } from "../lib/favoriteMusic";
 
 const SpotifyEmbed = () => {
   return (
     <div>
-      <iframe
-        className={styles.spotifyEmbed}
-        src="https://open.spotify.com/embed/album/76290XdXVF9rPzGdNRWdCh?utm_source=generator"
-        width="100%"
-        height="152"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      ></iframe>
-      <iframe
-        className={styles.spotifyEmbed}
-        src="https://open.spotify.com/embed/album/1BZoqf8Zje5nGdwZhOjAtD?utm_source=generator"
-        width="100%"
-        height="152"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      ></iframe>
-      <iframe
-        className={styles.spotifyEmbed}
-        src="https://open.spotify.com/embed/album/5wtE5aLX5r7jOosmPhJhhk?utm_source=generator"
-        width="100%"
-        height="152"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      ></iframe>
-      <iframe
-        className={styles.spotifyEmbed}
-        src="https://open.spotify.com/embed/album/3mVCQqgwEvwD7lHy9KHi7R?utm_source=generator"
-        width="100%"
-        height="152"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      ></iframe>
-      <iframe
-        className={styles.spotifyEmbed}
-        src="https://open.spotify.com/embed/album/7xV2TzoaVc0ycW7fwBwAml?utm_source=generator"
-        width="100%"
-        height="152"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      ></iframe>
-      <iframe
-        className={styles.spotifyEmbed}
-        src="https://open.spotify.com/embed/album/4VFG1DOuTeDMBjBLZT7hCK?utm_source=generator"
-        width="100%"
-        height="152"
-        frameBorder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-        loading="lazy"
-      ></iframe>
+      {favoriteAlbums.map((album) => (
+        <iframe
+          key={album.spotifyId}
+          className={styles.spotifyEmbed}
+          src={spotifyEmbedUrl(album.spotifyId)}
+          width="100%"
+          height="152"
+          frameBorder="0"
+          allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+          loading="lazy"
+          title={`${album.title} by ${album.artist}`}
+        />
+      ))}
     </div>
   );
 };

--- a/lib/favoriteMusic.js
+++ b/lib/favoriteMusic.js
@@ -1,0 +1,46 @@
+export const favoriteAlbums = [
+  {
+    spotifyId: "76290XdXVF9rPzGdNRWdCh",
+    title: "Ctrl",
+    artist: "SZA",
+    year: 2017,
+  },
+  {
+    spotifyId: "1BZoqf8Zje5nGdwZhOjAtD",
+    title: "The Miseducation of Lauryn Hill",
+    artist: "Lauryn Hill",
+    year: 1998,
+  },
+  {
+    spotifyId: "5wtE5aLX5r7jOosmPhJhhk",
+    title: "Swimming",
+    artist: "Mac Miller",
+    year: 2018,
+  },
+  {
+    spotifyId: "3mVCQqgwEvwD7lHy9KHi7R",
+    title: "...Nothing Like The Sun",
+    artist: "Sting",
+    year: 1987,
+  },
+  {
+    spotifyId: "7xV2TzoaVc0ycW7fwBwAml",
+    title: "Fine Line",
+    artist: "Harry Styles",
+    year: 2019,
+  },
+  {
+    spotifyId: "4VFG1DOuTeDMBjBLZT7hCK",
+    title: "Malibu",
+    artist: "Anderson .Paak",
+    year: 2016,
+  },
+];
+
+export function spotifyEmbedUrl(spotifyId) {
+  return `https://open.spotify.com/embed/album/${spotifyId}?utm_source=generator`;
+}
+
+export function spotifyAlbumUrl(spotifyId) {
+  return `https://open.spotify.com/album/${spotifyId}`;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -41,6 +41,10 @@ export default function Home({ allPostsData }) {
           <Link href={`/posts/recommend`} className={utilStyles.link}>
             reading
           </Link>
+          , listening to{" "}
+          <Link href={`/posts/music`} className={utilStyles.link}>
+            music
+          </Link>
           , or playing{" "}
           <Link href={`/posts/connections`} className={utilStyles.link}>
             puzzle games

--- a/pages/posts/about.js
+++ b/pages/posts/about.js
@@ -1,5 +1,6 @@
 import Layout, { siteTitle } from "../../components/layout";
 import Head from "next/head";
+import Link from "next/link";
 import utilStyles from "../../styles/utils.module.css";
 import styles from "../../styles/about.module.css";
 import "../../components/firebase";
@@ -44,6 +45,13 @@ export default function About() {
           <GifTV />
 
           <h1 className={headerFont.className}>Albums</h1>
+          <p>
+            See my full{" "}
+            <Link href="/posts/music" className={utilStyles.link}>
+              favorite music
+            </Link>{" "}
+            page for the complete list and Spotify previews.
+          </p>
           <SpotifyEmbed />
         </div>
       </article>

--- a/pages/posts/music.js
+++ b/pages/posts/music.js
@@ -1,0 +1,51 @@
+import Head from "next/head";
+import Link from "next/link";
+import Layout from "../../components/layout";
+import headerFont from "../../components/Font";
+import SpotifyEmbed from "../../components/MusicPlayer";
+import utilStyles from "../../styles/utils.module.css";
+import styles from "../../styles/music.module.css";
+import {
+  favoriteAlbums,
+  spotifyAlbumUrl,
+} from "../../lib/favoriteMusic";
+
+export default function Music() {
+  return (
+    <Layout>
+      <Head>
+        <title>Favorite Music</title>
+      </Head>
+      <h1 className={headerFont.className}>Favorite Music</h1>
+      <p className={styles.intro}>
+        These are albums I keep coming back to — the ones I reach for on long
+        walks, at the gym, or when I need something familiar. You can also find
+        books and TV on my{" "}
+        <Link href="/posts/about" className={utilStyles.link}>
+          about page
+        </Link>
+        .
+      </p>
+      <ol className={styles.albumList}>
+        {favoriteAlbums.map((album, index) => (
+          <li key={album.spotifyId} className={styles.albumListItem}>
+            <a
+              href={spotifyAlbumUrl(album.spotifyId)}
+              className={`${utilStyles.link} ${styles.albumLink}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {index + 1}. {album.title}
+            </a>
+            <span className={styles.albumMeta}>
+              {album.artist} · {album.year}
+            </span>
+          </li>
+        ))}
+      </ol>
+      <section className={styles.embedSection} aria-label="Spotify previews">
+        <SpotifyEmbed />
+      </section>
+    </Layout>
+  );
+}

--- a/styles/music.module.css
+++ b/styles/music.module.css
@@ -1,0 +1,43 @@
+/* Favorite music page */
+
+.intro {
+  border: 1px solid black;
+  font-size: 18px;
+  border-radius: 8px;
+  background-color: #f8f0ff;
+  padding: 32px;
+  margin-bottom: 24px;
+}
+
+.albumList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.albumListItem {
+  border: 1px solid black;
+  border-radius: 8px;
+  background-color: #fff8e8;
+  padding: 16px 20px;
+}
+
+.albumLink {
+  text-decoration: underline;
+}
+
+.albumMeta {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.embedSection {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated **Favorite Music** page at `/posts/music` that lists favorite albums with artist, year, and links to Spotify, plus embedded previews for each album.

## Changes

- New page: `pages/posts/music.js`
- Shared album data in `lib/favoriteMusic.js` (used by the new page and existing `MusicPlayer` component)
- Home page links to the music page in the intro paragraph
- About page links to the full music list

## Albums included

The page uses the same six albums already embedded on the About page: Ctrl (SZA), The Miseducation of Lauryn Hill, Swimming (Mac Miller), ...Nothing Like The Sun (Sting), Fine Line (Harry Styles), and Malibu (Anderson .Paak).

## How to test

1. Run `npm run dev`
2. Visit `/posts/music`
3. Confirm the numbered list and Spotify embeds load
4. Follow links from the home and about pages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f08221ef-adb6-4a0b-a175-98985026e667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f08221ef-adb6-4a0b-a175-98985026e667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

